### PR TITLE
Added custom protocol support for Battle.net game launch

### DIFF
--- a/composeApp/build.gradle.kts
+++ b/composeApp/build.gradle.kts
@@ -32,7 +32,7 @@ kotlin {
     }
 }
 
-version = "1.1.2"
+version = "1.1.3"
 
 tasks.withType(Jar::class.java).configureEach {
     manifest {

--- a/composeApp/src/jvmMain/kotlin/net/canyonwolf/sparklauncher/data/GameIndex.kt
+++ b/composeApp/src/jvmMain/kotlin/net/canyonwolf/sparklauncher/data/GameIndex.kt
@@ -47,7 +47,7 @@ object GameIndexManager {
             if (!Files.exists(file)) return GameIndex()
             val content = Files.readAllBytes(file).toString(StandardCharsets.UTF_8)
             fromJson(content)
-        } catch (e: Exception) {
+        } catch (_: Exception) {
             GameIndex()
         }
     }
@@ -106,11 +106,19 @@ object GameIndexManager {
                         val exe = findFirstExe(gameDir)
                         if (exe != null) {
                             val name = gameDir.name
+                            // Special-case: For Battle.net title "Call of Duty Modern Warfare III",
+                            // use a custom protocol path to ensure proper launching via Battle.net.
+                            val exePathStr =
+                                if (launcher == LauncherType.BATTLENET && name == "Call of Duty Modern Warfare III") {
+                                    "battlenet://game/pinta"
+                                } else {
+                                    exe.toString()
+                                }
                             result.add(
                                 GameEntry(
                                     launcher = launcher,
                                     name = name,
-                                    exePath = exe.toString(),
+                                    exePath = exePathStr,
                                     dirPath = gameDir.toString(),
                                 )
                             )


### PR DESCRIPTION
- Introduced handling for Battle.net-specific protocol paths (e.g., "battlenet://game/pinta") for games requiring special launch mechanisms, such as "Call of Duty Modern Warfare III."
- Modified LibraryScreen logic to use `exePath` equality instead of reference equality for selection checks.
- Adjusted `launchGame` to handle protocol URLs appropriately by invoking the system handler.
- Bumped app version to 1.1.3.